### PR TITLE
Add stock price fetcher

### DIFF
--- a/README_stock_prices.md
+++ b/README_stock_prices.md
@@ -1,0 +1,27 @@
+# Stock Price Fetcher
+
+This repository includes a small tool for retrieving the closing price of a
+U.S. stock ticker for a specific date. The information is stored in a
+`stock_prices` table so subsequent requests can be served from the database.
+
+## Setup
+1. Ensure a PostgreSQL database is available and a `db.conf` file describes how
+   to connect to it (see other scripts in this repo for the format).
+2. Install the Python dependencies for this project. `yfinance` is required for
+   retrieving stock prices:
+   ```bash
+   pip install yfinance
+   ```
+3. Create the table by executing:
+   ```bash
+   psql -f stock_price_schema.sql
+   ```
+
+## Usage
+Run the script with a ticker symbol and a date in `YYYY-MM-DD` format:
+```bash
+python get_stock_price.py AAPL 2024-05-10
+```
+The script will output the closing price and store it in the database.
+If the record already exists, the stored value is printed without reaching out
+to the network.

--- a/get_stock_price.py
+++ b/get_stock_price.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""Fetch and store closing stock prices.
+
+This script retrieves the closing price for a given ticker and date using
+`yfinance`, stores it in a PostgreSQL table and prints the result. If the
+record already exists in the database, it is returned without calling
+`yfinance`.
+"""
+
+import argparse
+from datetime import datetime, timedelta
+import pgconnect
+import yfinance as yf
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch closing stock price for a given ticker and date")
+    parser.add_argument("ticker", help="Stock ticker symbol, e.g. AAPL")
+    parser.add_argument("date", help="Date in YYYY-MM-DD format")
+    parser.add_argument(
+        "--database-config",
+        default="db.conf",
+        help="Parameters to connect to the database")
+    parser.add_argument(
+        "--schema-file",
+        default="stock_price_schema.sql",
+        help="SQL schema file for the stock_prices table")
+    args = parser.parse_args()
+
+    conn = pgconnect.connect(args.database_config)
+    cur = conn.cursor()
+
+    # Ensure the schema exists
+    with open(args.schema_file, "r") as f:
+        cur.execute(f.read())
+    conn.commit()
+
+    price_date = datetime.strptime(args.date, "%Y-%m-%d").date()
+    ticker = args.ticker.upper()
+
+    cur.execute(
+        "SELECT close_price FROM stock_prices WHERE ticker=%s AND price_date=%s",
+        (ticker, price_date),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        print(f"{ticker} {price_date} close price: {row[0]}")
+        return
+
+    # Fetch from yfinance. The end date is exclusive so we add one day.
+    start = price_date
+    end = price_date + timedelta(days=1)
+    data = yf.download(
+        ticker,
+        start=start.strftime("%Y-%m-%d"),
+        end=end.strftime("%Y-%m-%d"),
+        progress=False,
+    )
+    if data.empty:
+        raise SystemExit("No data returned for the given ticker and date")
+    close_price = float(data["Close"].iloc[0])
+
+    cur.execute(
+        "INSERT INTO stock_prices (ticker, price_date, close_price)"
+        " VALUES (%s, %s, %s)",
+        (ticker, price_date, close_price),
+    )
+    conn.commit()
+
+    print(f"{ticker} {price_date} close price: {close_price}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "requests>=2.32.3",
     "tqdm>=4.67.1",
+    "yfinance>=0.2.37",
 ]

--- a/stock_price_schema.sql
+++ b/stock_price_schema.sql
@@ -1,0 +1,7 @@
+-- Table to store historical closing prices for U.S. stocks
+CREATE TABLE IF NOT EXISTS stock_prices (
+    ticker TEXT NOT NULL,
+    price_date DATE NOT NULL,
+    close_price NUMERIC,
+    PRIMARY KEY (ticker, price_date)
+);


### PR DESCRIPTION
## Summary
- add `get_stock_price.py` to fetch/store closing prices with yfinance
- create `stock_price_schema.sql` defining `stock_prices` table
- document usage in `README_stock_prices.md`
- add yfinance dependency in `pyproject.toml`

## Testing
- `python -m py_compile get_stock_price.py`
