### PR TITLE
Handle missing yfinance data

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ To populate prices for many processed DEF 14A filings in bulk, run:
 ```bash
 ./fetch_prices_for_director_filings.py --stop-after 200
 ```
+Any ticker/date combination that can't be retrieved is recorded in the
+`stock_price_failures` table. A normal run skips these failures. Passing
+`--force` removes a prior failure entry and attempts the download again.
 
 ## Director Compensation Extraction Tool
 

--- a/schema.sql
+++ b/schema.sql
@@ -272,6 +272,14 @@ CREATE TABLE IF NOT EXISTS stock_prices (
     PRIMARY KEY (ticker, price_date)
 );
 
+-- Track failed attempts to retrieve a stock price
+CREATE TABLE IF NOT EXISTS stock_price_failures (
+    ticker TEXT NOT NULL,
+    price_date DATE NOT NULL,
+    failure_msg TEXT,
+    PRIMARY KEY (ticker, price_date)
+);
+
 -- Schema for the CIK to ticker mapping
 -- Create a new table for storing cikcode to ticker mappings
 CREATE TABLE IF NOT EXISTS cik_to_ticker (


### PR DESCRIPTION
## Summary
- add a stock_price_failures table
- record failed yfinance fetches and skip them on subsequent runs
- document the new failure table behavior

## Testing
- `python3 -m py_compile fetch_prices_for_director_filings.py stock_price.py`
- `pytest -q`