### PR TITLE
Fix stock price retrieval with MultiIndex DataFrames

### DIFF
--- a/stock_price.py
+++ b/stock_price.py
@@ -47,7 +47,10 @@ def fetch_stock_price(conn, ticker: str, price_date, *, force: bool = False,
     )
     if data.empty:
         raise RuntimeError("No data returned for the given ticker and date")
-    close_price = float(data["Close"].iat[0])
+    # ``yf.download`` may return a DataFrame with a MultiIndex in some
+    # situations.  Using ``iloc`` ensures we correctly pick the first row
+    # regardless of whether ``data["Close"]`` yields a Series or a DataFrame.
+    close_price = float(data["Close"].iloc[0])
 
     if not dummy_run:
         if force:


### PR DESCRIPTION
## Summary
- ensure closing price extraction works even if `yf.download` returns a DataFrame with a MultiIndex

## Testing
- `python -m py_compile stock_price.py fetch_prices_for_director_filings.py`