### PR TITLE
Fix stock price lookup query

### DIFF
--- a/fetch_prices_for_director_filings.py
+++ b/fetch_prices_for_director_filings.py
@@ -33,9 +33,9 @@ def main() -> None:
     query = """
         SELECT DISTINCT f.filingDate, t.ticker
           FROM filings f
-          JOIN director_compensation dc ON f.document_storage_url = dc.url
+          JOIN director_extractions de ON f.document_storage_url = de.url
           JOIN cik_to_ticker t ON f.cikcode = t.cikcode
-         WHERE f.form = 'DEF 14A' AND dc.processed = TRUE
+         WHERE f.form = 'DEF 14A'
          ORDER BY f.filingDate
     """
     cur.execute(query)


### PR DESCRIPTION
## Summary
- fetch stock price data for all extracted DEF 14A filings
- avoid pandas float deprecation by indexing scalar values correctly

## Testing
- `pytest -q`