### PR TITLE
Add database dump automation and sandbox setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,17 @@ hostname=mydb-server
 port=5432
 dbname=tech-skills
 
+[minified]
+user=foo
+password=hunter2
+hostname=mydb-server
+port=5432
+dbname=techskills_min
+
 [edgar]
 useragent="Greg Smith greg@example.com"
 ```
+The `[minified]` section defines a temporary database used for creating sanitized dumps.
 
 9. Run `uv run load_listed_company_submissions.py --progress`
 
@@ -273,3 +281,14 @@ WHERE dc.committee_name ILIKE '%audit%';
 The schema creates several tables including `director_extract_batches`,
 `director_compensation`, `director_details`, and `director_committees`, plus a
 view `director_compensation_summary` for easy access to combined data.
+
+## Sandbox Setup
+
+To create a sandbox environment with a populated database you can run:
+
+```bash
+./envsetup.sh
+```
+
+This installs PostgreSQL, downloads the Python dependencies via `uv run uvbootstrap.py`, creates a local `techskills` database and user, writes a `db.conf` file (including a `[minified]` section used for generating sanitized dumps), and restores the latest minified dump from <http://datadumps.ifost.org.au/tech-skills/techskills.sql.gz>.
+

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+sudo apt update
+sudo apt install -y postgresql
+
+uv run uvbootstrap.py
+
+# Create database and user if they don't already exist
+sudo -u postgres psql -c "CREATE USER techskills WITH PASSWORD 'techskills';" >/dev/null 2>&1 || true
+sudo -u postgres psql -c "CREATE DATABASE techskills OWNER techskills;" >/dev/null 2>&1 || true
+
+cat > db.conf <<EOC
+[database]
+user=techskills
+password=techskills
+hostname=localhost
+port=5432
+dbname=techskills
+
+[minified]
+user=techskills
+password=techskills
+hostname=localhost
+port=5432
+dbname=techskills_min
+
+[edgar]
+useragent="example@example.com"
+EOC
+
+wget -O techskills.sql.gz http://datadumps.ifost.org.au/tech-skills/techskills.sql.gz
+gunzip -f techskills.sql.gz
+psql -U techskills -d techskills -f techskills.sql
+rm techskills.sql

--- a/eveningcron.sh
+++ b/eveningcron.sh
@@ -9,3 +9,7 @@ uv run fetch_prices_for_director_filings.py --stop-after 200
 uv run board_stock_analysis.py
 uv run boards_website_generator.py
 rsync -a boards-website/ merah:/var/www/vhosts/boards.industrial-linguistics.com/htdocs/
+
+uv run make_minified_dump.py
+gzip -9 -f techskills.sql
+rsync -a techskills.sql.gz merah:/var/www/vhosts/datadumps.ifost.org.au/htdocs/tech-skills/techskills.sql.gz


### PR DESCRIPTION
## Summary
- add a `make_minified_dump.py` tool to produce a sanitized SQL dump using db.conf
- update `eveningcron.sh` to create the dump, compress it and rsync it
- provide `envsetup.sh` for bootstrapping a new PostgreSQL instance and loading the dump
- document the new `[minified]` section and sandbox setup instructions in README

## Testing
- `python -m py_compile make_minified_dump.py`
