### PR TITLE
Fix DB loading in envsetup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # Notes for Codex Agents
 
 - The script `uvbootstrap.py` is executed when Codex sets up the environment. It downloads all Python dependencies using `uv`. If you recreate the environment manually, run `uv run uvbootstrap.py` to ensure requirements are installed.
+- If the environment variable `SANDBOX_HAS_DATABASE` is set to `yes`, then PostgreSQL has been set up with the connection details stored in `db.conf`. If `SANDBOX_HAS_DATABASE` is `no`, envsetup.sh hasn't been executed and there is no point running it because you are in a sandbox without internet access.

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -38,7 +38,27 @@ dbname=techskills_min
 useragent="example@example.com"
 EOC
 
+# Set up environment variables for convenient PostgreSQL access
+export PGHOST=localhost
+export PGHOSTNAME=localhost
+export PGPORT=5432
+export PGUSER=techskills
+export PGDATABASE=techskills
+
+# Persist them for future shells
+cat >> ~/.profile <<EOS
+export PGHOST=localhost
+export PGHOSTNAME=localhost
+export PGPORT=5432
+export PGUSER=techskills
+export PGDATABASE=techskills
+EOS
+
+# Configure passwordless access via .pgpass
+echo "localhost:5432:*:techskills:techskills" > ~/.pgpass
+chmod 600 ~/.pgpass
+
 wget -O techskills.sql.gz http://datadumps.ifost.org.au/tech-skills/techskills.sql.gz
 gunzip -f techskills.sql.gz
-psql -U techskills -d techskills -f techskills.sql
+psql -f techskills.sql
 rm techskills.sql


### PR DESCRIPTION
## Summary
- avoid Peer authentication errors when loading data into PostgreSQL
- set .pgpass and PG environment variables in `envsetup.sh`
- note SANDBOX_HAS_DATABASE meaning in AGENTS.md

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683a24e1236083259a4b0ca0f50db159