### PR TITLE
Add yfinance sector lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Options:
 - `--verbose`: Show detailed logging information
 - `--only-cikcode`: Process only one specific CIK code (for debugging)
 
-The schema also creates a view `company_ticker_info` and a helper function
-`get_company_by_ticker` for easier querying.
+The schema also creates a view `company_ticker_info` (now including a `sector`
+column) and a helper function `get_company_by_ticker` for easier querying.
 
 ### Usage Examples
 ```sql
@@ -196,6 +196,18 @@ To populate prices for many processed DEF 14A filings in bulk, run:
 Any ticker/date combination that can't be retrieved is recorded in the
 `stock_price_failures` table. A normal run skips these failures. Passing
 `--force` removes a prior failure entry and attempts the download again.
+
+### Fetching Sector Information
+
+You can also use `yfinance` to look up the industry sector for a ticker and
+store it in the `ticker_sector` table. Run:
+
+```bash
+./fetch_sector.py AAPL
+```
+
+Use `--force` to refresh an existing entry or `--dummy-run` to skip inserting
+into the database.
 
 ## Director Compensation Extraction Tool
 

--- a/fetch_sector.py
+++ b/fetch_sector.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Fetch and store the industry sector for a stock ticker."""
+
+import argparse
+
+import pgconnect
+import yfinance as yf
+
+
+def fetch_sector(conn, ticker: str, *, force: bool = False,
+                 schema_file: str = "schema.sql", dummy_run: bool = False) -> str:
+    """Fetch the sector for ``ticker`` and store it in the ``ticker_sector`` table.
+
+    When ``force`` is False an existing value is returned without contacting the
+    network.
+    """
+
+    ticker = ticker.upper()
+    cur = conn.cursor()
+
+    # Ensure table exists
+    with open(schema_file, "r", encoding="utf-8") as f:
+        cur.execute(f.read())
+        conn.commit()
+
+    if not force:
+        cur.execute(
+            "SELECT sector FROM ticker_sector WHERE ticker=%s",
+            (ticker,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return row[0]
+
+    info = yf.Ticker(ticker).info
+    sector = info.get("sector")
+    if not sector:
+        raise RuntimeError("Sector information unavailable")
+
+    if not dummy_run:
+        cur.execute(
+            "INSERT INTO ticker_sector (ticker, sector) VALUES (%s, %s) "
+            "ON CONFLICT (ticker) DO UPDATE SET sector = EXCLUDED.sector",
+            (ticker, sector),
+        )
+        conn.commit()
+
+    return sector
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch and store the sector for a stock ticker",
+    )
+    parser.add_argument("ticker", help="Stock ticker symbol, e.g. AAPL")
+    parser.add_argument("--database-config", default="db.conf",
+                        help="Parameters to connect to the database")
+    parser.add_argument("--schema-file", default="schema.sql",
+                        help="SQL schema file to ensure tables exist")
+    parser.add_argument("--force", action="store_true",
+                        help="Refetch sector even if already stored")
+    parser.add_argument("--dummy-run", action="store_true",
+                        help="Don't store the result in the database")
+    args = parser.parse_args()
+
+    conn = pgconnect.connect(args.database_config)
+    sector = fetch_sector(
+        conn,
+        args.ticker,
+        force=args.force,
+        schema_file=args.schema_file,
+        dummy_run=args.dummy_run,
+    )
+    print(f"{args.ticker.upper()} sector: {sector}")
+
+
+if __name__ == "__main__":
+    main()

--- a/schema.sql
+++ b/schema.sql
@@ -280,6 +280,12 @@ CREATE TABLE IF NOT EXISTS stock_price_failures (
     PRIMARY KEY (ticker, price_date)
 );
 
+-- Store sector information for each ticker
+CREATE TABLE IF NOT EXISTS ticker_sector (
+    ticker TEXT PRIMARY KEY,
+    sector TEXT
+);
+
 -- Schema for the CIK to ticker mapping
 -- Create a new table for storing cikcode to ticker mappings
 CREATE TABLE IF NOT EXISTS cik_to_ticker (
@@ -299,18 +305,22 @@ CREATE OR REPLACE VIEW company_ticker_info AS
 SELECT
     c.cikcode,
     c.company_name,
-    t.ticker
+    t.ticker,
+    s.sector
 FROM
     cik2name c
 JOIN
-    cik_to_ticker t ON c.cikcode = t.cikcode;
+    cik_to_ticker t ON c.cikcode = t.cikcode
+LEFT JOIN
+    ticker_sector s ON t.ticker = s.ticker;
 
 -- Create a function to find a company by ticker
 CREATE OR REPLACE FUNCTION get_company_by_ticker(ticker_symbol VARCHAR)
 RETURNS TABLE (
     cikcode INT,
     company_name VARCHAR,
-    ticker VARCHAR
+    ticker VARCHAR,
+    sector VARCHAR
 ) AS $$
 BEGIN
     RETURN QUERY


### PR DESCRIPTION
## Summary
- add `fetch_sector.py` for pulling sector info from yfinance
- store sectors in new `ticker_sector` table
- expose sector in `company_ticker_info` view and helper function
- document new sector fetcher in the README

## Testing
- `python -m py_compile fetch_sector.py`

------
https://chatgpt.com/codex/tasks/task_e_683a356e97708325925bc808b5de1b71