### PR TITLE
Limit database dump to Sundays

### DIFF
--- a/eveningcron.sh
+++ b/eveningcron.sh
@@ -10,6 +10,9 @@ uv run board_stock_analysis.py
 uv run boards_website_generator.py
 rsync -a boards-website/ merah:/var/www/vhosts/boards.industrial-linguistics.com/htdocs/
 
-#uv run make_minified_dump.py
-#gzip -9 -f techskills.sql
-#rsync -a techskills.sql.gz merah:/var/www/vhosts/datadumps.ifost.org.au/htdocs/tech-skills/techskills.sql.gz
+# Only create and upload a database dump on Sundays
+if [ "$(date +%u)" -eq 7 ]; then
+    uv run make_minified_dump.py
+    gzip -9 -f techskills.sql
+    rsync -a techskills.sql.gz merah:/var/www/vhosts/datadumps.ifost.org.au/htdocs/tech-skills/techskills.sql.gz
+fi


### PR DESCRIPTION
## Summary
- run database dump in `eveningcron.sh` only on Sundays

## Testing
- `bash -n eveningcron.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7d4eeed083258a086310115339ca