### PR TITLE
Add director name resolution framework

### DIFF
--- a/documentation/director_name_resolution.md
+++ b/documentation/director_name_resolution.md
@@ -59,3 +59,14 @@ EDGAR itself does not provide a persistent director ID. BoardEx and similar data
 - Track history of name changes (e.g. marriage) by analysing biography text.
 - Periodically retrain the classifier as more labelled data becomes available.
 
+### Provided Tools
+Two helper programs implement the above process:
+
+- `train_name_matcher.py` trains a logistic regression model from a CSV file of
+  labelled name pairs (`name1,name2,label`). The resulting model is saved to a
+  file for later use.
+- `resolve_director_names.py` applies a trained model to names extracted in the
+  `director_mentions` view and populates the new `directors` and
+  `director_name_aliases` tables. It falls back to simple normalisation when no
+  model is supplied.
+

--- a/name_matcher.py
+++ b/name_matcher.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Utilities for matching director names.
+
+Provides normalisation routines and a small logistic-regression
+classifier for determining when two names likely refer to the same
+individual.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+import pickle
+from typing import Iterable, Tuple
+
+from sklearn.linear_model import LogisticRegression
+
+import director_name_handling
+
+SUFFIXES = {"JR", "SR", "II", "III", "IV", "V"}
+
+
+def _strip_accents(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in normalized if not unicodedata.combining(c))
+
+
+def normalise_name(name: str) -> str:
+    """Return a canonical representation of a person's name."""
+    name = _strip_accents(name)
+    name = director_name_handling.remove_name_suffixes(name)
+    name = re.sub(r"[^A-Za-z0-9 ]", "", name)
+    parts = name.upper().split()
+    parts = [p for p in parts if p not in SUFFIXES]
+    return " ".join(parts)
+
+
+def _ngrams(text: str, n: int = 3) -> set[str]:
+    padded = f" {text} "
+    return {padded[i : i + n] for i in range(len(padded) - n + 1)}
+
+
+def trigram_similarity(a: str, b: str) -> float:
+    """Jaccard similarity on character trigrams of two strings."""
+    ng_a = _ngrams(normalise_name(a))
+    ng_b = _ngrams(normalise_name(b))
+    if not ng_a or not ng_b:
+        return 0.0
+    intersection = len(ng_a & ng_b)
+    union = len(ng_a | ng_b)
+    return intersection / union
+
+
+def levenshtein(a: str, b: str) -> int:
+    """Simple Levenshtein distance implementation."""
+    a = normalise_name(a)
+    b = normalise_name(b)
+    if len(a) < len(b):
+        a, b = b, a
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        current = [i]
+        for j, cb in enumerate(b, 1):
+            insert = current[j - 1] + 1
+            delete = previous[j] + 1
+            replace = previous[j - 1] + (ca != cb)
+            current.append(min(insert, delete, replace))
+        previous = current
+    return previous[-1]
+
+
+def feature_vector(a: str, b: str) -> list[float]:
+    return [
+        trigram_similarity(a, b),
+        levenshtein(a, b),
+    ]
+
+
+class NameMatcher:
+    """Thin wrapper around ``sklearn`` logistic regression for name matching."""
+
+    def __init__(self, model: LogisticRegression | None = None):
+        self.model = model or LogisticRegression()
+
+    def train(self, pairs: Iterable[Tuple[str, str, int]]):
+        X = []
+        y = []
+        for n1, n2, label in pairs:
+            X.append(feature_vector(n1, n2))
+            y.append(label)
+        self.model.fit(X, y)
+
+    def score(self, a: str, b: str) -> float:
+        X = [feature_vector(a, b)]
+        return float(self.model.predict_proba(X)[0][1])
+
+    def save(self, path: str):
+        with open(path, "wb") as f:
+            pickle.dump(self.model, f)
+
+    @classmethod
+    def load(cls, path: str) -> "NameMatcher":
+        with open(path, "rb") as f:
+            model = pickle.load(f)
+        return cls(model)
+

--- a/resolve_director_names.py
+++ b/resolve_director_names.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Populate canonical director tables based on extracted names."""
+
+import argparse
+from typing import List, Tuple
+import os
+
+import pgconnect
+from name_matcher import NameMatcher, normalise_name
+
+
+def fetch_distinct_names(cursor, source_view: str) -> List[str]:
+    cursor.execute(f"SELECT DISTINCT director_name FROM {source_view}")
+    return [r[0] for r in cursor.fetchall()]
+
+
+def load_matcher(model_file: str | None) -> NameMatcher | None:
+    if model_file and os.path.exists(model_file):
+        return NameMatcher.load(model_file)
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resolve director names")
+    parser.add_argument("--database-config", default="db.conf", help="DB config file")
+    parser.add_argument("--model-file", help="Trained matcher model")
+    parser.add_argument("--threshold", type=float, default=0.8, help="Match probability threshold")
+    parser.add_argument("--source-view", default="director_mentions", help="Where to read names from")
+    args = parser.parse_args()
+
+    conn = pgconnect.connect(args.database_config)
+    read = conn.cursor()
+    write = conn.cursor()
+
+    matcher = load_matcher(args.model_file)
+
+    existing = {}
+    write.execute("SELECT id, canonical_name FROM directors")
+    for row in write.fetchall():
+        existing[row[1]] = row[0]
+
+    names = fetch_distinct_names(read, args.source_view)
+
+    for name in names:
+        canonical = normalise_name(name)
+        director_id = existing.get(canonical)
+
+        if director_id is None and matcher is not None:
+            # attempt fuzzy match
+            best_id = None
+            best_score = 0.0
+            for canon, did in existing.items():
+                score = matcher.score(name, canon)
+                if score > best_score:
+                    best_score = score
+                    best_id = did
+            if best_score >= args.threshold:
+                director_id = best_id
+
+        if director_id is None:
+            write.execute(
+                "INSERT INTO directors (canonical_name) VALUES (%s) RETURNING id",
+                [canonical],
+            )
+            director_id = write.fetchone()[0]
+            existing[canonical] = director_id
+
+        write.execute(
+            "INSERT INTO director_name_aliases (director_id, alias, source) "
+            "VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+            [director_id, name, args.source_view],
+        )
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/schema.sql
+++ b/schema.sql
@@ -264,6 +264,24 @@ SELECT
 FROM
     director_details d;
 
+-- Canonical list of directors resolved from variant names
+CREATE TABLE IF NOT EXISTS directors (
+    id SERIAL PRIMARY KEY,
+    canonical_name TEXT UNIQUE NOT NULL,
+    biography TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_directors_canonical ON directors(canonical_name);
+
+-- Observed name aliases for each director
+CREATE TABLE IF NOT EXISTS director_name_aliases (
+    id SERIAL PRIMARY KEY,
+    director_id INT REFERENCES directors(id),
+    alias TEXT NOT NULL,
+    source TEXT,
+    UNIQUE(director_id, alias)
+);
+CREATE INDEX IF NOT EXISTS idx_director_name_alias ON director_name_aliases(alias);
+
 -- Table to store historical closing prices for U.S. stocks
 CREATE TABLE IF NOT EXISTS stock_prices (
     ticker TEXT NOT NULL,

--- a/train_name_matcher.py
+++ b/train_name_matcher.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Train a name matching model from labelled CSV data."""
+
+import argparse
+import csv
+from typing import List
+
+from name_matcher import NameMatcher
+
+
+def load_pairs(csv_file: str) -> List[tuple[str, str, int]]:
+    pairs = []
+    with open(csv_file, newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 3:
+                continue
+            name1, name2, label = row[0], row[1], int(row[2])
+            pairs.append((name1, name2, label))
+    return pairs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train director name matcher")
+    parser.add_argument("training_csv", help="CSV with name1,name2,label")
+    parser.add_argument("--model-file", default="name_matcher.pkl", help="Where to store the trained model")
+    args = parser.parse_args()
+
+    pairs = load_pairs(args.training_csv)
+    matcher = NameMatcher()
+    matcher.train(pairs)
+    matcher.save(args.model_file)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- implement canonical director tables for consolidating name variants
- provide normalization and matching utilities in `name_matcher.py`
- add scripts to train a model and populate the new tables
- document the new workflow

## Testing
- `python -m py_compile name_matcher.py train_name_matcher.py resolve_director_names.py`

------
https://chatgpt.com/codex/tasks/task_e_683a82c280248325a22579e636db67ec