### PR TITLE
Fix fetch_all_sectors stop-after logic

### DIFF
--- a/fetch_all_sectors.py
+++ b/fetch_all_sectors.py
@@ -58,7 +58,7 @@ def main() -> None:
 
     count = 0
     for ticker in iterator:
-        if args.stop_after and count >= args.stop_after:
+        if args.stop_after is not None and count >= args.stop_after:
             break
         try:
             fetch_sector(
@@ -69,8 +69,8 @@ def main() -> None:
             )
         except Exception as exc:  # pylint: disable=broad-except
             logging.error("Failed to fetch sector for %s: %s", ticker, exc)
-        else:
-            count += 1
+            conn.rollback()
+        count += 1
 
     conn.close()
 

--- a/morningcron.sh
+++ b/morningcron.sh
@@ -4,4 +4,4 @@ cd $(dirname $0)
 
 uv run ask_openai_bulk.py --stop-after 100
 uv run extract_director_compensation.py --stop-after 110
-uv run fetch_all_sectors.py --stop-after 100 --progress
+uv run fetch_all_sectors.py --stop-after 100


### PR DESCRIPTION
## Summary
- stop fetch_all_sectors after the specified number of tickers even if errors occur
- roll back the DB connection on failures so further ticks proceed
- remove the progress bar flag from `morningcron.sh`

## Testing
- `python -m py_compile fetch_all_sectors.py`
- `bash -n morningcron.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844b84fff148325a9c20b246f27acc4