### PR TITLE
Fix fetch_sector table handling and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ Any ticker/date combination that can't be retrieved is recorded in the
 ### Fetching Sector Information
 
 You can use `yfinance` to look up the industry sector for a ticker and store it
-in the `ticker_sector` table. Run:
+in the `ticker_sector` table. The script automatically creates the table if it
+is missing. Run:
 
 ```bash
 ./fetch_sector.py AAPL

--- a/fetch_all_sectors.py
+++ b/fetch_all_sectors.py
@@ -30,8 +30,6 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch sectors for all tickers")
     parser.add_argument("--database-config", default="db.conf",
                         help="Parameters to connect to the database")
-    parser.add_argument("--schema-file", default="schema.sql",
-                        help="SQL schema file to ensure tables exist")
     parser.add_argument("--stop-after", type=int,
                         help="Limit number of tickers processed")
     parser.add_argument("--progress", action="store_true",
@@ -65,7 +63,6 @@ def main() -> None:
                 conn,
                 ticker,
                 force=args.force,
-                schema_file=args.schema_file,
             )
         except Exception as exc:  # pylint: disable=broad-except
             logging.error("Failed to fetch sector for %s: %s", ticker, exc)

--- a/tests/test_fetch_sector.py
+++ b/tests/test_fetch_sector.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+
+def test_fetch_sector_aapl():
+    result = subprocess.run(
+        [sys.executable, 'fetch_sector.py', 'AAPL', '--dummy-run'],
+        capture_output=True, text=True
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 0
+    assert 'AAPL sector:' in result.stdout
+
+
+if __name__ == '__main__':
+    test_fetch_sector_aapl()
+


### PR DESCRIPTION
## Summary
- create ticker_sector table on demand in `fetch_sector`
- note automatic table creation in README
- add a simple smoke test for `fetch_sector.py`

## Testing
- `python -m py_compile fetch_sector.py fetch_all_sectors.py tests/test_fetch_sector.py`
- `python tests/test_fetch_sector.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6844bd184c2083259b81d389b0298015