### PR TITLE
Add manual sector inserts

### DIFF
--- a/manual_sector_inserts.sql
+++ b/manual_sector_inserts.sql
@@ -1,0 +1,12 @@
+-- Insert known sectors for tickers with previously missing information
+INSERT INTO ticker_sector (ticker, sector) VALUES
+    ('AAAU', 'Financial Services'),
+    ('AACT-WT', 'Financial Services'),
+    ('AAGO', 'Financial Services'),
+    ('AAM-WT', 'Financial Services'),
+    ('AAS', 'Financial Services'),
+    ('ABLLL', 'Financial Services'),
+    ('ABLLW', 'Financial Services'),
+    ('ACHR-WT', 'Industrials'),
+    ('ACLEW', 'Healthcare')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- include manual sector inserts for tickers with missing info

## Testing
- `uv run uvbootstrap.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6847879e67fc8325bfc9db8949c4367f