### PR TITLE
Update manual sectors and cron settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,5 @@
 
 - The script `uvbootstrap.py` is executed when Codex sets up the environment. It downloads all Python dependencies using `uv`. If you recreate the environment manually, run `uv run uvbootstrap.py` to ensure requirements are installed.
 - If the environment variable `SANDBOX_HAS_DATABASE` is set to `yes`, then PostgreSQL has been set up with the connection details stored in `db.conf`. If `SANDBOX_HAS_DATABASE` is `no`, envsetup.sh hasn't been executed and there is no point running it because you are in a sandbox without internet access.
+
+- When sector fetches fail (e.g. 404 or "Sector information unavailable" errors), add the missing ticker sectors to `manual_sector_inserts.sql` and commit them.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ done
 
 That will run `uv run ask_openai_batch.py --stop-after 100`,
 `uv run extract_director_compensation.py --stop-after 110` and
-`uv run fetch_all_sectors.py --stop-after 100 --progress` to gradually
+`uv run fetch_all_sectors.py --stop-after 500 --progress` to gradually
 populate the sector table.
 
 I haven't figured out how to make sure the batches aren't too big or too small. I'm just
@@ -217,7 +217,7 @@ To populate sectors for every ticker in `cik_to_ticker`, run `fetch_all_sectors.
 It supports `--stop-after` and `--progress` to throttle requests:
 
 ```bash
-./fetch_all_sectors.py --stop-after 100 --progress
+./fetch_all_sectors.py --stop-after 500 --progress
 ```
 
 ## Director Compensation Extraction Tool

--- a/manual_sector_inserts.sql
+++ b/manual_sector_inserts.sql
@@ -8,5 +8,14 @@ INSERT INTO ticker_sector (ticker, sector) VALUES
     ('ABLLL', 'Financial Services'),
     ('ABLLW', 'Financial Services'),
     ('ACHR-WT', 'Industrials'),
-    ('ACLEW', 'Healthcare')
+    ('ACLEW', 'Healthcare'),
+    ('ADZCF', 'Financial Services'),
+    ('AEAEW', 'Financial Services'),
+    ('AEFC', 'Financial Services'),
+    ('AERGP', 'Industrials'),
+    ('AFBL', 'Financial Services'),
+    ('AFGB', 'Financial Services'),
+    ('AFGC', 'Financial Services'),
+    ('AFGD', 'Financial Services'),
+    ('AFGE', 'Financial Services')
 ON CONFLICT DO NOTHING;

--- a/morningcron.sh
+++ b/morningcron.sh
@@ -4,4 +4,4 @@ cd $(dirname $0)
 
 uv run ask_openai_bulk.py --stop-after 100
 uv run extract_director_compensation.py --stop-after 110
-uv run fetch_all_sectors.py --stop-after 100
+uv run fetch_all_sectors.py --stop-after 500


### PR DESCRIPTION
## Summary
- document that missing ticker sectors must be filled in manually
- add more manually defined ticker sectors
- fetch more sector entries each day
- reflect changed sector batch size in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6848e2172c608325acbc9507d072cdb7