### PR TITLE
Fix eigenvector centrality convergence

### DIFF
--- a/boards_website_generator.py
+++ b/boards_website_generator.py
@@ -582,7 +582,10 @@ def generate_network_visualization(output_dir, conn):
 
     for component in nx.connected_components(G):
         sub = G.subgraph(component)
-        centrality = nx.eigenvector_centrality(sub)
+        try:
+            centrality = nx.eigenvector_centrality(sub, max_iter=1000)
+        except nx.PowerIterationFailedConvergence:
+            centrality = nx.eigenvector_centrality_numpy(sub)
         for node, score in centrality.items():
             G.nodes[node]["centrality"] = score
 


### PR DESCRIPTION
## Summary
- handle `PowerIterationFailedConvergence` when calculating eigenvector centrality

## Testing
- `python tests/test_fetch_sector.py` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ac161a0188325a84c10524a425a95