### PR TITLE
Fix duplicated v1 path in batch requests

### DIFF
--- a/ask_openai_bulk.py
+++ b/ask_openai_bulk.py
@@ -208,7 +208,7 @@ For each director, clearly state:
     batch_text = {
         "custom_id": url,
         "method": "POST",
-        "url": "/v1/chat/completions",
+        "url": "/chat/completions",
         "body": {
             "model": "gpt-4.1-mini",
             "messages": [{"role": "system", "content": system_prompt}, { "role": "user", "content": text_version}],
@@ -241,7 +241,7 @@ batch_input_file = client.files.create(
 
 result = client.batches.create(
     input_file_id=batch_input_file.id,
-    endpoint="/v1/chat/completions",
+    endpoint="/chat/completions",
     completion_window="24h",
     metadata={
         "description": f"techskills batch {batch_id}",

--- a/extract_director_compensation.py
+++ b/extract_director_compensation.py
@@ -247,7 +247,7 @@ If any information is not available for a director, use appropriate default valu
     batch_text = {
         "custom_id": url,
         "method": "POST",
-        "url": "/v1/chat/completions",
+        "url": "/chat/completions",
         "body": {
             "model": "gpt-4.1-mini",
             "messages": [{"role": "system", "content": system_prompt}, { "role": "user", "content": text_version}],
@@ -280,7 +280,7 @@ batch_input_file = client.files.create(
 
 result = client.batches.create(
     input_file_id=batch_input_file.id,
-    endpoint="/v1/chat/completions",
+    endpoint="/chat/completions",
     completion_window="24h",
     metadata={
         "description": f"director_compensation batch {batch_id}",


### PR DESCRIPTION
## Summary
- update batch request definitions to use /chat/completions rather than /v1/chat/completions
- adjust batches.create endpoint argument accordingly to avoid double /v1 prefix

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf9920c7083258ab77e9d49676b98