### PR TITLE
Fix OpenAI batch endpoint path

### DIFF
--- a/extract_director_compensation.py
+++ b/extract_director_compensation.py
@@ -247,7 +247,7 @@ If any information is not available for a director, use appropriate default valu
     batch_text = {
         "custom_id": url,
         "method": "POST",
-        "url": "/chat/completions",
+        "url": "/v1/chat/completions",
         "body": {
             "model": "gpt-4.1-mini",
             "messages": [{"role": "system", "content": system_prompt}, { "role": "user", "content": text_version}],
@@ -280,7 +280,7 @@ batch_input_file = client.files.create(
 
 result = client.batches.create(
     input_file_id=batch_input_file.id,
-    endpoint="/chat/completions",
+    endpoint="/v1/chat/completions",
     completion_window="24h",
     metadata={
         "description": f"director_compensation batch {batch_id}",


### PR DESCRIPTION
## Summary
- update the batch request payload in `extract_director_compensation.py` to use the `/v1/chat/completions` endpoint
- ensure the batch submission also targets `/v1/chat/completions` so OpenAI accepts the request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d37028c3988325936e80b25abf627f