### PR TITLE
Fix batch endpoint paths for OpenAI requests

### DIFF
--- a/ask_openai_bulk.py
+++ b/ask_openai_bulk.py
@@ -208,7 +208,7 @@ For each director, clearly state:
     batch_text = {
         "custom_id": url,
         "method": "POST",
-        "url": "/v1/chat/completions",
+        "url": "/chat/completions",
         "body": {
             "model": "gpt-4.1-mini",
             "messages": [{"role": "system", "content": system_prompt}, { "role": "user", "content": text_version}],
@@ -230,7 +230,7 @@ if args.dry_run:
     sys.exit(0)
 
 
-EXPECTED_BATCH_ENDPOINT = "/v1/chat/completions"
+EXPECTED_BATCH_ENDPOINT = "/chat/completions"
 
 
 def validate_batch_requests(batch_file_path):
@@ -287,7 +287,7 @@ batch_input_file = client.files.create(
 
 result = client.batches.create(
     input_file_id=batch_input_file.id,
-    endpoint="/v1/chat/completions",
+    endpoint="/chat/completions",
     completion_window="24h",
     metadata={
         "description": f"techskills batch {batch_id}",

--- a/extract_director_compensation.py
+++ b/extract_director_compensation.py
@@ -247,7 +247,7 @@ If any information is not available for a director, use appropriate default valu
     batch_text = {
         "custom_id": url,
         "method": "POST",
-        "url": "/v1/chat/completions",
+        "url": "/chat/completions",
         "body": {
             "model": "gpt-4.1-mini",
             "messages": [{"role": "system", "content": system_prompt}, { "role": "user", "content": text_version}],
@@ -280,7 +280,7 @@ batch_input_file = client.files.create(
 
 result = client.batches.create(
     input_file_id=batch_input_file.id,
-    endpoint="/v1/chat/completions",
+    endpoint="/chat/completions",
     completion_window="24h",
     metadata={
         "description": f"director_compensation batch {batch_id}",


### PR DESCRIPTION
## Summary
- update OpenAI batch request payloads to target /chat/completions instead of the incorrect /v1/chat/completions path
- adjust endpoint validation constant to match the corrected path

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3e6f7dff4832597d17ff48e6c78cf